### PR TITLE
Fix Vite base path for GitHub Pages

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 import path from 'node:path';
 
 export default defineConfig({
+  base: './',
   resolve: {
     alias: {
       '@data': path.resolve(__dirname, 'data'),


### PR DESCRIPTION
## Summary
- set the Vite base path to a relative URL so GitHub Pages can resolve built assets

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68db29d93cf88321ba7c52b1d4c67cc3