### PR TITLE
Fix GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
+      - name: Configure Pages
+        uses: actions/configure-pages@v4
       - run: npm install
       - name: Lint (tsc)
         run: npm run lint
@@ -32,7 +34,7 @@ jobs:
       - name: Build
         run: npm run build
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: dist
 
@@ -46,4 +48,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v3
+        uses: actions/deploy-pages@v4

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 import path from 'node:path';
 
 export default defineConfig({
+  base: './',
   resolve: {
     alias: {
       '@data': path.resolve(__dirname, 'data'),


### PR DESCRIPTION
## Summary
- configure the build job with actions/configure-pages before uploading the Pages artifact
- update the deploy job to use actions/deploy-pages@v4 for compatibility with the latest Pages APIs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db29d93cf88321ba7c52b1d4c67cc3